### PR TITLE
Reorganize the code of benchmark

### DIFF
--- a/requirements-bench.txt
+++ b/requirements-bench.txt
@@ -1,9 +1,9 @@
 genutility
 lmdbm==0.0.5
-pysos==1.2.5
+pysos==1.2.9
 pytablewriter==0.63.0
 semidbm==0.5.1
 sqlitedict==1.7.0
 unqlite==0.9.2
 vedis==0.7.1
-wiredtiger-dbm==0.0.1
+rocksdict==0.3.5


### PR DESCRIPTION
Decouple the common steps and database implementations. With this it is easy to add new implementations and remove missing ones.

Also separate single writes and batch writes, since in almost every implementation the batch write is faster.

Initiate MAX_TIME to stop spending infinite time calculating very slow implementations.

Add combined case: in real world the key/value stores are not used to store the whole database, then read the whole database. In the combined case the same number of writes and reads are calculated for different database sizes.

WiredTiger is missing from PyPi, so I removed that.

Added SQLite WAL mode, since it is much faster even with autocommit than the existing two.